### PR TITLE
Defensive Concurrency in Go Blog Post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ public/
 *.aes
 
 *.env
+
+node_modules/

--- a/.spelling
+++ b/.spelling
@@ -1,0 +1,33 @@
+# markdown-spellcheck spelling configuration file
+# Format - lines beginning # are comments
+# global dictionary is at the start, file overrides afterwards
+# one word per line, to define a file override use ' - filename'
+# where filename is relative to this configuration file
+struct
+mutex
+buildkit
+artifacts
+OCI
+frontends
+dockerfile
+cli
+protobuf
+STDIN
+frontend
+Github
+walkthrough
+STDOUT
+ - content/posts/defensive-concurrency-in-go.md
+4
+5
+1
+3
+PseuGo
+i
+vi
+inflight
+ - content/posts/getting-started-with-buildkit.md
+peepz
+Walkthrough
+tonistiigi
+292

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,17 @@
 build:
 	hugo
 
+.PHONY: spellcheck
+spellcheck:
+	npm test
+
 .PHONY: release
 release: build
 	aws s3 sync ./public s3://george.macro.re/
 
 .PHONY: docker-release
 docker-release: docker-build
-	docker run -v `pwd`:/site georgemac/hugo release 
+	docker run -v `pwd`:/site georgemac/hugo release
 
 .PHONY: docker
 docker: docker-build

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -2,3 +2,6 @@ hugo:
   build: .
   cached: true
   encrypted_env_file: env.encrypted
+spellcheck:
+  build:
+    dockerfile_path: spelling.Dockerfile

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,6 +1,12 @@
-- name: build 
-  service: hugo 
-  command: "build"
+- name: validate
+  type: parallel
+  steps:
+    - name: build
+      service: hugo
+      command: "build"
+    - name: spellcheck
+      service: spellcheck
+      command: "npm test"
 - name: release
   tag: master
   service: hugo

--- a/content/posts/defensive-concurrency-in-go.md
+++ b/content/posts/defensive-concurrency-in-go.md
@@ -1,0 +1,194 @@
+---
+title: "Defensive Concurrency in Go"
+date: 2018-01-21T15:43:31Z
+tags: ["go", "goroutines", "channels", "concurrency", "defensive programming"]
+draft: true
+---
+
+Before I get to deep in to the weeds of this post. I want to set some expectations.
+
+This is not an explanation of how to solve a well understood problem with a textbook solution. Nor is it necessarily the ideal solution to the problem itself.
+This solution is the product of avoiding scope creep and minimizing the surface area of a refactor.
+
+## Setting The Stage
+
+When I first drafted this blog post, this paragraph was as a drawn out tail of the original technical problem. It was a little over defensive and full of boring details. 
+
+Instead here is the gist of the problem and some context:
+
+1. A key component of a large codebase needs refactoring.
+2. This key components has a single function interface.
+3. The function takes a struct, which contains the attributes of a resource which needs to be "realized". Think of the type as a factory or constructor of things.
+4. The callers of this function will call concurrently. Often for the something already requested by other callers. Infact other callers could still be waiting on the same thing to be built, or could be long gone with the result they needed.
+5. We should only do the work of creating the resulting resource once per unique set of attributes.
+
+This blog post is not entirely concerned with addressing the first three points above. Instead it is focused on points number 4 and 5.
+How do we protect our single function type from concurrent callers, often requesting the same work or work that has already been done, in such a way that we only do work once per unique set of attributes?
+
+```go
+type Make struct {}
+
+func (m Make) Make(Attributes) (thing Thing, err error) {
+  // stuff happens and it could take a long time
+  return
+}
+```
+
+For illustration purposes, take the above type as being the solution to steps 1 through 3. The type takes some `Attributes` struct and realizes it as a `Thing` resource.
+The goal is to defend this type from greedy callers. Of course it goes without saying that it should all be easily unit testable as well.
+
+To simplify testing and to separate concerns, the solution presented will be defined as a decorator. Callers will instead communicate with a Go interface, rather than the concrete `Make` implementation.
+
+```go
+type Maker interface {
+    Make(Attributes) (Thing, error)
+}
+```
+
+The `Make` type satisfies this interface and so will the defensive implementation. However, the defensive implementation will wrap other implementations of the `Maker` interface and delegate down.
+
+```go
+type DefensiveMaker struct {
+    Maker
+}
+
+func (d DefensiveMaker) Make(attrs Attributes) (Thing, error) {
+    return d.Maker.Make(attrs)
+}
+```
+
+This will be the canvas for the eventual solution.
+
+Given greater scope this could be solved by addressing the access patterns of the callers described in point 4 above. However, as I have already mentioned, the solution I am going to describe is about solving this problem while minimizing the surface area of the change throughout the rest of the codebase.
+
+## A Solution
+
+Time for a little PseuGo code (Coining this now. You heard it here first)
+
+### Naive defensive approach 
+
+```go
+type result struct {
+    thing Thing
+    err   error
+}
+```
+
+1. Lock a mutex on every call to `Make(...)`
+2. Use the `Attributes` as a key in a map of already evaluated results
+3. If the attributes have already been evaluated return the "cached" result
+4. Otherwise, delegate the `Make(...)` call, save the result in the map and return it
+
+```go
+type DefensiveMaker struct {
+    Maker
+    mu sync.Mutex
+    results map[Attribute]result
+}
+
+func (d DefensiveMaker) Make(attrs Attributes) (Thing, error) {
+    d.mu.Lock()
+    defer d.mu.Unlock()
+
+    // has it been done already?
+    if res, ok := d.results[attrs]; ok {
+        // yeah, return the cached result
+        return res.thing, res.err
+    }
+
+    // not yet, do the real work
+    thing, err := d.Maker.Make(attrs)
+
+    // save the result
+    d.results[attrs] = result{thing, err}
+
+    return thing, err
+}
+```
+
+This does work. However, the impact of doing this leads to all calls to `Make(...)` becoming serialized. If `Make(...)` takes a long time, all other callers are blocked. The question is, is it possible to unblock callers requesting attributes which have not yet been requested?
+
+### A less "blocky" approach 
+
+```go
+type inflight struct {
+  ready chan struct{}
+  thing Thing
+  err   error
+}
+```
+
+1. On entry to `Make` lock a mutex
+2. Look up the `Attributes` in a `map[Attrubutes]*inflight` calls to see if this has been requested yet
+3. If it **has** already been requested:
+
+    i. unlock the mutex
+
+    ii. retrieve the `ready` channel stored on the inflight call struct
+
+    iii. receive on the `ready` channel until it unblocks
+
+    iv. return the `inflight.thing` and the `inflight.err` as the result of the call
+
+4. If it **has not** yet been requested:
+
+    i. first construct an `inflight{ready: make(chan struct{})}` struct with an unbuffered `ready` channel
+
+    ii. `defer` closing the ready channel to notify other callers for the same `Attributes` 
+
+    iii. store a pointer to the `inflight` struct in the map, using the `Attributes` as a key 
+
+    iv. unlock the mutex (now other callers can safely share `DefensiveMaker`)
+
+    v. do the real `Make(...)` call 
+
+    vi. capture the result on the originally constructed `inflight` pointer 
+
+The advantage of this approach is that the time spent holding the `Lock` (worst case) is limited to retrieval/storage in a map and construction of inflight type. Calls for resources already inflight, block on the `ready` channel until the first successful call for the same `Attributes` finishes. Results for the same `Attributes` are calculated once, but different results for different `Attributes` can be calculated concurrently.
+
+Let's see this in Go:
+
+```go
+type DefensiveMaker struct {
+    Maker
+
+    mu      sync.Mutex
+    results map[Attribute]*inflight
+}
+
+func (d DefensiveMaker) Make(attrs Attributes) (Thing, error) {
+    d.mu.Lock()
+
+    // has it been done already?
+    if res, ok := d.results[attrs]; ok {
+        // yeah, so don't hold up any other callers
+        // we can wait on the inflight ready channel
+        d.mu.Unlock()
+
+        // wait until result is ready
+        <-res.ready
+
+        // return the cached result
+        return res.thing, res.err
+    }
+
+    // construct an inflight to track the call against
+    inflight := inflight{ready: make(chan struct{})}
+
+    // defer closing ready channel to notify callers with the same attributes
+    defer close(inflight.ready)
+
+    // save the inflight call for others to get notified on
+    d.results[attrs] = &inflight
+
+    // unblock other callers
+    d.mu.Unlock()
+
+    // delegate to the embedded and save the result on the inflight 
+    inflight.thing, inflight.err = d.Maker.Make(attrs)
+
+    return inflight.thing, inflight.err 
+}
+```
+
+Now any implementation of the `Maker` interface can be decorated and protected against nasty, greedy callers. Ideally we would whip the callers in to shape and we wouldn't have to be so defensive. However, in the real world we don't always have the time or resources to undertake larger refactors like that. In the short term we can use the lovely Go concurrency primitives and libraries to keep our code safe! 

--- a/content/posts/defensive-concurrency-in-go.md
+++ b/content/posts/defensive-concurrency-in-go.md
@@ -2,7 +2,6 @@
 title: "Defensive Concurrency in Go"
 date: 2018-01-21T15:43:31Z
 tags: ["go", "goroutines", "channels", "concurrency", "defensive programming"]
-draft: true
 ---
 
 Before I get to deep in to the weeds of this post. I want to set some expectations.
@@ -19,7 +18,7 @@ Instead here is the gist of the problem and some context:
 1. A key component of a large codebase needs refactoring.
 2. This key components has a single function interface.
 3. The function takes a struct, which contains the attributes of a resource which needs to be "realized". Think of the type as a factory or constructor of things.
-4. The callers of this function will call concurrently. Often for the something already requested by other callers. Infact other callers could still be waiting on the same thing to be built, or could be long gone with the result they needed.
+4. The callers of this function will call concurrently. Often for the something already requested by other callers. In fact other callers could still be waiting on the same thing to be built, or could be long gone with the result they needed.
 5. We should only do the work of creating the resulting resource once per unique set of attributes.
 
 This blog post is not entirely concerned with addressing the first three points above. Instead it is focused on points number 4 and 5.

--- a/content/posts/getting-started-with-buildkit.md
+++ b/content/posts/getting-started-with-buildkit.md
@@ -10,17 +10,17 @@ The clever peepz over at Moby are clearly hard at work revolutionising the way w
 
 ## What is BuildKit?
 
-In a nutshell BuildKit is an engine which interprets a graph of instructions into a target container image format. With the ability to target multiple export formats (e.g. OCI or docker), support multiple frontends (e.g. Dockerfile) and provide all sorts of wonderful features such as efficient layer caching and operation parallization.
+In a nutshell BuildKit is an engine which interprets a graph of instructions into a target container image format. With the ability to target multiple export formats (e.g. OCI or docker), support multiple frontends (e.g. Dockerfile) and provide all sorts of wonderful features such as efficient layer caching and operation parallelization.
 
-BuildKit is seperate from Docker and only requires a container runtime to facilitate the execution of operations to create image layers. The currently supported runtimes are `containerd` and plain old `runc`.
+BuildKit is separate from Docker and only requires a container runtime to facilitate the execution of operations to create image layers. The currently supported runtime's are `containerd` and plain old `runc`.
 
 The BuildKit project itself consists of two key components. The first being the build daemon `buildkitd`. The second being a cli tool called `buildctl` which is used to facilitate command line communication with the `buildkitd` instance.
 
 The BuildKit cli `buildctl` is configured to receive a graph based IR (intermediate representation) of operations. This IR is called `llb` which stands for `low-level builder`. This format is defined in the BuildKit project using protobuf. The `buildctl` command itself expects an `llb` to be marshalled in this format on STDIN. Currently there are some handy Go libraries for describing and marshalling an `llb` to an `io.Writer`. However, since the format is protobuf it will be really easy to port `llb` generating code to other languages. As a die hard gopher myself though, I am fortunate enough to be able to start hacking on this right away.
 
-It is the `llb` medium which facilitates BuildKits ability to have multiple frontends. There currently exists an experimental frontend for `Dockerfile`. I believe the intent of this project is to replace the current docker builder baked into the `docker` command.
+It is the `llb` medium which facilitates BuildKit's ability to have multiple frontends. There currently exists an experimental frontend for `Dockerfile`. I believe the intent of this project is to replace the current docker builder baked into the `docker` command.
 
-The BuildKit github project contains an `examples` folder with lots of Go binaries which spit protobuf encoded `llb` instructions which can be piped into `buildctl`, examined and then executed. I am going to walk through how this can be achieved on a mac.
+The BuildKit Github project contains an `examples` folder with lots of Go binaries which spit protobuf encoded `llb` instructions which can be piped into `buildctl`, examined and then executed. I am going to walk through how this can be achieved on a mac.
 
 ## Walkthrough
 
@@ -84,7 +84,7 @@ This has been taken directly from the [Buildkit README](https://github.com/moby/
     buildctl build --help
 
 Now we can start playing with BuildKit. For the purpose of this walkthrough, we will use `examples/buildkit0`. The aim of this example is to build `buildkit` itself along with `runc` and `containerd`.
-To help us understand this, we are going to use the `buildctl debug dump-llb` command to convert the `llb` protobuf into a more readible JSON array of layer operations. Then we will pipe the JSON through `jq` to prettify.
+To help us understand this, we are going to use the `buildctl debug dump-llb` command to convert the `llb` protobuf into a more readable JSON array of layer operations. Then we will pipe the JSON through `jq` to prettify.
 
     go run examples/buildkit0/buildkit.go | ./bin/buildctl-darwin debug dump-llb | jq '.'
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "george.macro.re",
+  "version": "0.1.0",
+  "description": "https://george.macro.re blog",
+  "scripts": {
+    "test": "mdspell -rn 'content/**/*.md'",
+    "fix": "mdspell -n 'content/**/*.md'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/georgemac/macro.re.git"
+  },
+  "keywords": [
+    "george",
+    "macrorie",
+    "golang",
+    "containers"
+  ],
+  "author": "George MacRorie",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/georgemac/macro.re/issues"
+  },
+  "homepage": "http://george.macro.re",
+  "dependencies": {
+    "markdown-spellcheck": "^1.0.0"
+  }
+}

--- a/spelling.Dockerfile
+++ b/spelling.Dockerfile
@@ -1,0 +1,9 @@
+FROM node:latest
+
+ADD . /repo
+
+WORKDIR /repo
+
+RUN npm install
+
+CMD ["npm", "test"]


### PR DESCRIPTION
1. `Defensive Concurrency in Go` blog post
2. Spellchecking capability in release pipeline
3. Corrected some spellcheck errors